### PR TITLE
index.txt: fix broken screenshot URL

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -4,7 +4,7 @@ django-request
 
 django-request is a statistics module for django. It stores requests in a database for admins to see, it can also be used to get statistics on who is online etc.
 
-.. image:: http://media.kylefuller.co.uk/projects/django-request/graph.png
+.. image:: https://raw.githubusercontent.com/kylef/django-request/master/docs/graph.png
     :height: 272 px
     :width: 480 px
 


### PR DESCRIPTION
The old URL has disappeared. Point to the screenshot on github.

---

This also needs to be updated on https://pypi.python.org/pypi/django-request
