### PR TITLE
Feature: Log Request Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 django-request
 ==============
 
-[![Build Status](http://img.shields.io/travis/kylef/django-request/master.svg?style=flat)](https://travis-ci.org/kylef/django-request)
+[![Build Status](https://travis-ci.org/ojengwa/django-request.svg?branch=master)](https://travis-ci.org/ojengwa/django-request)
 
 django-request is a statistics module for django. It stores requests in a database for admins to see, it can also be used to get statistics on who is online etc.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 django-request
 ==============
 
-[![Build Status](https://travis-ci.org/ojengwa/django-request.svg?branch=master)](https://travis-ci.org/ojengwa/django-request)
+[![Build Status](https://travis-ci.org/ojengwa/django-request.svg?branch=feature-log-request-data)](https://travis-ci.org/ojengwa/django-request)
 
 django-request is a statistics module for django. It stores requests in a database for admins to see, it can also be used to get statistics on who is online etc.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 django-request
 ==============
 
-[![Build Status](https://travis-ci.org/ojengwa/django-request.svg?branch=feature-log-request-data)](https://travis-ci.org/ojengwa/django-request)
+[![Build Status](https://travis-ci.org/kylef/django-request.svg?branch=feature-log-request-data)](https://travis-ci.org/kylef/django-request)
 
 django-request is a statistics module for django. It stores requests in a database for admins to see, it can also be used to get statistics on who is online etc.
 

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -46,6 +46,13 @@ Default: ``True``
 
 If set to False, user are not logged (set to None).
 
+``REQUEST_LOG_DATA``
+=====================
+
+Default: ``False``
+
+If set to True, the data that came as part of the request will be logged.
+
 ``REQUEST_IGNORE_USERNAME``
 ===========================
 
@@ -88,7 +95,7 @@ Example:
 ``REQUEST_TRAFFIC_MODULES``
 =================================
 
-Default: 
+Default:
 
 .. code-block:: python
 
@@ -116,7 +123,7 @@ These are all the items in the traffic graph and table on the overview page. If 
 ``REQUEST_PLUGINS``
 ===================
 
-Default: 
+Default:
 
 .. code-block:: python
 

--- a/request/admin.py
+++ b/request/admin.py
@@ -19,14 +19,14 @@ class RequestAdmin(admin.ModelAdmin):
             'fields': ('method', 'path', 'time', 'is_secure', 'is_ajax')
         }),
         (_('Response'), {
-            'fields': ('response',)
+            'fields': ('response', 'data')
         }),
         (_('User info'), {
             'fields': ('referer', 'user_agent', 'ip', 'user', 'language')
         })
     )
     raw_id_fields = ('user',)
-    readonly_fields = ('time',)
+    readonly_fields = ('time', 'data')
 
     def lookup_allowed(self, key, value):
         return key == 'user__username' or super(RequestAdmin, self).lookup_allowed(key, value)

--- a/request/admin.py
+++ b/request/admin.py
@@ -19,14 +19,14 @@ class RequestAdmin(admin.ModelAdmin):
             'fields': ('method', 'path', 'time', 'is_secure', 'is_ajax')
         }),
         (_('Response'), {
-            'fields': ('response', 'data')
+            'fields': ('response',)
         }),
         (_('User info'), {
             'fields': ('referer', 'user_agent', 'ip', 'user', 'language')
         })
     )
     raw_id_fields = ('user',)
-    readonly_fields = ('time', 'data')
+    readonly_fields = ('time',)
 
     def lookup_allowed(self, key, value):
         return key == 'user__username' or super(RequestAdmin, self).lookup_allowed(key, value)

--- a/request/admin.py
+++ b/request/admin.py
@@ -19,19 +19,20 @@ class RequestAdmin(admin.ModelAdmin):
             'fields': ('method', 'path', 'time', 'is_secure', 'is_ajax')
         }),
         (_('Response'), {
-            'fields': ('response',)
+            'fields': ('response', 'data')
         }),
         (_('User info'), {
             'fields': ('referer', 'user_agent', 'ip', 'user', 'language')
         })
     )
     raw_id_fields = ('user',)
-    readonly_fields = ('time',)
+    readonly_fields = ('time', 'data')
 
     def lookup_allowed(self, key, value):
         return key == 'user__username' or super(RequestAdmin, self).lookup_allowed(key, value)
 
     def request_from(self, obj):
+        print(obj, dir(obj), vars(obj))
         if obj.user_id:
             user = obj.get_user()
             return '<a href="?user__username=%s" title="%s">%s</a>' % (user.username, _('Show only requests from this user.'), user)

--- a/request/migrations/0001_initial.py
+++ b/request/migrations/0001_initial.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import models, migrations
 from django.conf import settings
+import jsonfield
 
 
 class Migration(migrations.Migration):
@@ -15,18 +16,30 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Request',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('response', models.SmallIntegerField(default=200, verbose_name='response', choices=[(100, 'Continue'), (101, 'Switching Protocols'), (102, 'Processing (WebDAV)'), (200, 'OK'), (201, 'Created'), (202, 'Accepted'), (203, 'Non-Authoritative Information'), (204, 'No Content'), (205, 'Reset Content'), (206, 'Partial Content'), (207, 'Multi-Status (WebDAV)'), (300, 'Multiple Choices'), (301, 'Moved Permanently'), (302, 'Found'), (303, 'See Other'), (304, 'Not Modified'), (305, 'Use Proxy'), (306, 'Switch Proxy'), (307, 'Temporary Redirect'), (400, 'Bad Request'), (401, 'Unauthorized'), (402, 'Payment Required'), (403, 'Forbidden'), (404, 'Not Found'), (405, 'Method Not Allowed'), (406, 'Not Acceptable'), (407, 'Proxy Authentication Required'), (408, 'Request Timeout'), (409, 'Conflict'), (410, 'Gone'), (411, 'Length Required'), (412, 'Precondition Failed'), (413, 'Request Entity Too Large'), (414, 'Request-URI Too Long'), (415, 'Unsupported Media Type'), (416, 'Requested Range Not Satisfiable'), (417, 'Expectation Failed'), (418, "I'm a teapot"), (422, 'Unprocessable Entity (WebDAV)'), (423, 'Locked (WebDAV)'), (424, 'Failed Dependency (WebDAV)'), (425, 'Unordered Collection'), (426, 'Upgrade Required'), (449, 'Retry With'), (500, 'Internal Server Error'), (501, 'Not Implemented'), (502, 'Bad Gateway'), (503, 'Service Unavailable'), (504, 'Gateway Timeout'), (505, 'HTTP Version Not Supported'), (506, 'Variant Also Negotiates'), (507, 'Insufficient Storage (WebDAV)'), (509, 'Bandwidth Limit Exceeded'), (510, 'Not Extended')])),
-                ('method', models.CharField(default=b'GET', max_length=7, verbose_name='method')),
-                ('path', models.CharField(max_length=255, verbose_name='path')),
-                ('time', models.DateTimeField(auto_now_add=True, verbose_name='time')),
-                ('is_secure', models.BooleanField(default=False, verbose_name='is secure')),
-                ('is_ajax', models.BooleanField(default=False, help_text='Wheather this request was used via javascript.', verbose_name='is ajax')),
+                ('id', models.AutoField(
+                    verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('response', models.SmallIntegerField(default=200, verbose_name='response', choices=[(100, 'Continue'), (101, 'Switching Protocols'), (102, 'Processing (WebDAV)'), (200, 'OK'), (201, 'Created'), (202, 'Accepted'), (203, 'Non-Authoritative Information'), (204, 'No Content'), (205, 'Reset Content'), (206, 'Partial Content'), (207, 'Multi-Status (WebDAV)'), (300, 'Multiple Choices'), (301, 'Moved Permanently'), (302, 'Found'), (303, 'See Other'), (304, 'Not Modified'), (305, 'Use Proxy'), (306, 'Switch Proxy'), (307, 'Temporary Redirect'), (400, 'Bad Request'), (401, 'Unauthorized'), (402, 'Payment Required'), (403, 'Forbidden'), (404, 'Not Found'), (405, 'Method Not Allowed'), (406, 'Not Acceptable'), (407, 'Proxy Authentication Required'), (408, 'Request Timeout'), (
+                    409, 'Conflict'), (410, 'Gone'), (411, 'Length Required'), (412, 'Precondition Failed'), (413, 'Request Entity Too Large'), (414, 'Request-URI Too Long'), (415, 'Unsupported Media Type'), (416, 'Requested Range Not Satisfiable'), (417, 'Expectation Failed'), (418, "I'm a teapot"), (422, 'Unprocessable Entity (WebDAV)'), (423, 'Locked (WebDAV)'), (424, 'Failed Dependency (WebDAV)'), (425, 'Unordered Collection'), (426, 'Upgrade Required'), (449, 'Retry With'), (500, 'Internal Server Error'), (501, 'Not Implemented'), (502, 'Bad Gateway'), (503, 'Service Unavailable'), (504, 'Gateway Timeout'), (505, 'HTTP Version Not Supported'), (506, 'Variant Also Negotiates'), (507, 'Insufficient Storage (WebDAV)'), (509, 'Bandwidth Limit Exceeded'), (510, 'Not Extended')])),
+                ('data', jsonfield.fields.JSONField(verbose_name='data')),
+                ('method', models.CharField(
+                    default=b'GET', max_length=7, verbose_name='method')),
+                ('path', models.CharField(
+                    max_length=255, verbose_name='path')),
+                ('time', models.DateTimeField(
+                    auto_now_add=True, verbose_name='time')),
+                ('is_secure', models.BooleanField(
+                    default=False, verbose_name='is secure')),
+                ('is_ajax', models.BooleanField(
+                    default=False, help_text='Wheather this request was used via javascript.', verbose_name='is ajax')),
                 ('ip', models.IPAddressField(verbose_name='ip address')),
-                ('referer', models.URLField(max_length=255, null=True, verbose_name='referer', blank=True)),
-                ('user_agent', models.CharField(max_length=255, null=True, verbose_name='user agent', blank=True)),
-                ('language', models.CharField(max_length=255, null=True, verbose_name='language', blank=True)),
-                ('user', models.ForeignKey(verbose_name='user', blank=True, to=settings.AUTH_USER_MODEL, null=True)),
+                ('referer', models.URLField(
+                    max_length=255, null=True, verbose_name='referer', blank=True)),
+                ('user_agent', models.CharField(
+                    max_length=255, null=True, verbose_name='user agent', blank=True)),
+                ('language', models.CharField(
+                    max_length=255, null=True, verbose_name='language', blank=True)),
+                ('user', models.ForeignKey(
+                    verbose_name='user', blank=True, to=settings.AUTH_USER_MODEL, null=True)),
             ],
             options={
                 'ordering': ('-time',),

--- a/request/models.py
+++ b/request/models.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 from socket import gethostbyaddr
+from collections import OrderedDict
 
 from django.db import models
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.utils.translation import ugettext_lazy as _
+
+from jsonfield import JSONField
 
 from request.managers import RequestManager
 from request.utils import HTTP_STATUS_CODES, browsers, engines
@@ -16,22 +19,32 @@ AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
 class Request(models.Model):
     # Response infomation
-    response = models.SmallIntegerField(_('response'), choices=HTTP_STATUS_CODES, default=200)
+    response = models.SmallIntegerField(
+        _('response'), choices=HTTP_STATUS_CODES, default=200)
 
     # Request infomation
     method = models.CharField(_('method'), default='GET', max_length=7)
     path = models.CharField(_('path'), max_length=255)
     time = models.DateTimeField(_('time'), auto_now_add=True)
 
+    # Request payload.
+    data = JSONField(_('data'),
+                     load_kwargs={'object_pairs_hook': OrderedDict})
+
     is_secure = models.BooleanField(_('is secure'), default=False)
-    is_ajax = models.BooleanField(_('is ajax'), default=False, help_text=_('Wheather this request was used via javascript.'))
+    is_ajax = models.BooleanField(_('is ajax'), default=False, help_text=_(
+        'Wheather this request was used via javascript.'))
 
     # User infomation
     ip = models.GenericIPAddressField(_('ip address'))
-    user = models.ForeignKey(AUTH_USER_MODEL, blank=True, null=True, verbose_name=_('user'))
-    referer = models.URLField(_('referer'), max_length=255, blank=True, null=True)
-    user_agent = models.CharField(_('user agent'), max_length=255, blank=True, null=True)
-    language = models.CharField(_('language'), max_length=255, blank=True, null=True)
+    user = models.ForeignKey(
+        AUTH_USER_MODEL, blank=True, null=True, verbose_name=_('user'))
+    referer = models.URLField(
+        _('referer'), max_length=255, blank=True, null=True)
+    user_agent = models.CharField(
+        _('user agent'), max_length=255, blank=True, null=True)
+    language = models.CharField(
+        _('language'), max_length=255, blank=True, null=True)
 
     objects = RequestManager()
 
@@ -105,7 +118,7 @@ class Request(models.Model):
         elif request_settings.REQUEST_ANONYMOUS_IP:
             parts = self.ip.split('.')[0:-1]
             parts.append('1')
-            self.ip='.'.join(parts)
+            self.ip = '.'.join(parts)
         if not request_settings.REQUEST_LOG_USER:
             self.user = None
 

--- a/request/models.py
+++ b/request/models.py
@@ -75,6 +75,8 @@ class Request(models.Model):
                     self.data = request.POST
                 else:
                     self.data = request.GET
+        else:
+            self.data = {}
 
         # User infomation
         self.ip = request.META.get('REMOTE_ADDR', '')

--- a/request/models.py
+++ b/request/models.py
@@ -67,6 +67,11 @@ class Request(models.Model):
         self.is_secure = request.is_secure()
         self.is_ajax = request.is_ajax()
 
+        try:
+            self.data = request.body
+        except Exception, e:
+            self.data = {}
+
         # User infomation
         self.ip = request.META.get('REMOTE_ADDR', '')
         self.referer = request.META.get('HTTP_REFERER', '')[:255]

--- a/request/models.py
+++ b/request/models.py
@@ -67,10 +67,14 @@ class Request(models.Model):
         self.is_secure = request.is_secure()
         self.is_ajax = request.is_ajax()
 
-        try:
-            self.data = request.body
-        except Exception, e:
-            self.data = {}
+        if request_settings.REQUEST_LOG_DATA:
+            try:
+                self.data = request.body
+            except Exception, e:
+                if request.method == 'POST':
+                    self.data = request.POST
+                else:
+                    self.data = request.GET
 
         # User infomation
         self.ip = request.META.get('REMOTE_ADDR', '')

--- a/request/models.py
+++ b/request/models.py
@@ -70,7 +70,7 @@ class Request(models.Model):
         if request_settings.REQUEST_LOG_DATA:
             try:
                 self.data = request.body
-            except Exception, e:
+            except Exception(e):
                 if request.method == 'POST':
                     self.data = request.POST
                 else:

--- a/request/settings.py
+++ b/request/settings.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 
-REQUEST_VALID_METHOD_NAMES = getattr(settings, 'REQUEST_VALID_METHOD_NAMES', ('get', 'post', 'put', 'delete', 'head', 'options', 'trace'))
+REQUEST_VALID_METHOD_NAMES = getattr(
+    settings, 'REQUEST_VALID_METHOD_NAMES', ('get', 'post', 'put', 'delete', 'head', 'options', 'trace'))
 
 REQUEST_ONLY_ERRORS = getattr(settings, 'REQUEST_ONLY_ERRORS', False)
 REQUEST_IGNORE_AJAX = getattr(settings, 'REQUEST_IGNORE_AJAX', False)
@@ -9,9 +10,11 @@ REQUEST_LOG_IP = getattr(settings, 'REQUEST_LOG_IP', True)
 REQUEST_IP_DUMMY = getattr(settings, 'REQUEST_IP_DUMMY', "1.1.1.1")
 REQUEST_ANONYMOUS_IP = getattr(settings, 'REQUEST_ANONYMOUS_IP', False)
 REQUEST_LOG_USER = getattr(settings, 'REQUEST_LOG_USER', True)
+REQUEST_LOG_DATA = getattr(settings, 'REQUEST_LOG_DATA', False)
 REQUEST_IGNORE_USERNAME = getattr(settings, 'REQUEST_IGNORE_USERNAME', tuple())
 REQUEST_IGNORE_PATHS = getattr(settings, 'REQUEST_IGNORE_PATHS', tuple())
-REQUEST_IGNORE_USER_AGENTS = getattr(settings, 'REQUEST_IGNORE_USER_AGENTS', tuple())
+REQUEST_IGNORE_USER_AGENTS = getattr(
+    settings, 'REQUEST_IGNORE_USER_AGENTS', tuple())
 
 REQUEST_TRAFFIC_MODULES = getattr(settings, 'REQUEST_TRAFFIC_MODULES', (
     'request.traffic.UniqueVisitor',
@@ -33,6 +36,8 @@ REQUEST_PLUGINS = getattr(settings, 'REQUEST_PLUGINS', (
 try:
     from django.http import HttpRequest
     from django.contrib.sites.shortcuts import get_current_site
-    REQUEST_BASE_URL = getattr(settings, 'REQUEST_BASE_URL', 'http://%s' % get_current_site( HttpRequest() ).domain)
+    REQUEST_BASE_URL = getattr(
+        settings, 'REQUEST_BASE_URL', 'http://%s' % get_current_site(HttpRequest()).domain)
 except:
-    REQUEST_BASE_URL = getattr(settings, 'REQUEST_BASE_URL', 'http://127.0.0.1')
+    REQUEST_BASE_URL = getattr(
+        settings, 'REQUEST_BASE_URL', 'http://127.0.0.1')

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,12 @@ setup(
 
     As well as a site statistics module, with the active_users template tag and manager method you can also use django-request to show who is online in a certain time.
     """,
-    author='Kyle Fuller',
-    author_email='kyle@fuller.li',
+    author='Bernard Ojengwa',
+    author_email='bernardojengwa@gmail.com',
     url=request.__URL__,
-    download_url='http://github.com/kylef/django-request/archive/%s.zip' % request.__version__,
-    packages=['request', 'request.migrations', 'request.templatetags', 'request.management', 'request.management.commands'],
+    download_url='http://github.com/ojengwa/django-request/archive/%s.zip' % request.__version__,
+    packages=['request', 'request.migrations', 'request.templatetags',
+              'request.management', 'request.management.commands'],
     package_data={'request': [
         'templates/admin/request/*.html',
         'templates/admin/request/request/*.html',
@@ -27,6 +28,7 @@ setup(
     ]},
     install_requires=[
         'django',
+        'jsonfield'
     ],
     license=request.__licence__,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ setup(
 
     As well as a site statistics module, with the active_users template tag and manager method you can also use django-request to show who is online in a certain time.
     """,
-    author='Bernard Ojengwa',
-    author_email='bernardojengwa@gmail.com',
+    author='Kyle Fuller',
+    author_email='inbox@kylefuller.co.uk',
     url=request.__URL__,
-    download_url='http://github.com/ojengwa/django-request/archive/%s.zip' % request.__version__,
+    download_url='http://github.com/kylef/django-request/archive/%s.zip' % request.__version__,
     packages=['request', 'request.migrations', 'request.templatetags',
               'request.management', 'request.management.commands'],
     package_data={'request': [

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -37,7 +37,8 @@ class RequestTests(unittest.TestCase):
         self.assertEqual(request.browser, None)
 
     def test_browser_detection_with_no_path(self):
-        request = Request(user_agent='Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:43.0) Gecko/20100101 Firefox/43.0')
+        request = Request(
+            user_agent='Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:43.0) Gecko/20100101 Firefox/43.0')
         self.assertEqual(request.browser, 'Firefox')
 
     def test_determining_search_keywords_with_no_referer(self):
@@ -49,3 +50,32 @@ class RequestTests(unittest.TestCase):
             referer='https://www.google.com/search?client=safari&rls=en&q=querykit+core+data&ie=UTF-8&oe=UTF-8'
         )
         self.assertEqual(request.keywords, 'querykit core data')
+
+    def test_request_data(self):
+        data = {
+            "login": "kylef",
+            "id": 44164,
+            "avatar_url": "https://avatars.githubusercontent.com/u/44164?v=3",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/kylef",
+            "html_url": "https://github.com/kylef",
+            "type": "User",
+            "site_admin": False,
+            "name": "Kyle Fuller",
+            "company": "Apiary",
+            "blog": "https://fuller.li/",
+            "location": "London, England",
+            "email": "kyle@fuller.li",
+            "hireable": True,
+            "bio": None,
+            "public_repos": 152,
+            "public_gists": 38,
+            "followers": 806,
+            "following": 89,
+            "created_at": "2009-01-04T22:54:57Z",
+            "updated_at": "2016-02-03T12:40:01Z"
+        }
+        request = Request(data=data)
+
+        self.assertEqual(request.response, 200)
+        self.assertDictEqual(request.data, data)


### PR DESCRIPTION
As a trade-off, I added an extra a settings parameter `REQUEST_LOG_DATA` which determines whether the Request payload should be logged. Also, I noticed that Django only allows the request's data stream to be read once. [You cannot access body after reading from request's data stream](https://code.djangoproject.com/ticket/16822). This is mostly caused by middlewares (Django CORs Headers, in my case).