### PR TITLE
transform http headers to uppercase, created page_hits template tag

### DIFF
--- a/request/models.py
+++ b/request/models.py
@@ -61,10 +61,9 @@ class Request(models.Model):
         self.is_ajax = request.is_ajax()
 
         # User infomation
-        if 'HTTP_X_REAL_IP' in request.META:
-            # record real ip from header if was set
-            self.ip = request.META.get('HTTP_X_REAL_IP', '')
-        else:
+        # record real ip from header if was set
+        self.ip = request.META.get('HTTP_X_REAL_IP', '')
+        if not self.ip:
             self.ip = request.META.get('REMOTE_ADDR', '')
         self.referer = request.META.get('HTTP_REFERER', '')[:255]
         self.user_agent = request.META.get('HTTP_USER_AGENT', '')[:255]

--- a/request/models.py
+++ b/request/models.py
@@ -9,7 +9,7 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 from request import settings as request_settings
 from request.managers import RequestManager
-from request.utils import HTTP_STATUS_CODES, browsers, engines
+from request.utils import HTTP_STATUS_CODES, browsers, engines, transform_http_headers
 
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
@@ -54,6 +54,9 @@ class Request(models.Model):
 
     def from_http_request(self, request, response=None, commit=True):
         # Request infomation
+        
+        transform_http_headers(request)
+
         self.method = request.method
         self.path = request.path[:255]
 

--- a/request/models.py
+++ b/request/models.py
@@ -61,7 +61,11 @@ class Request(models.Model):
         self.is_ajax = request.is_ajax()
 
         # User infomation
-        self.ip = request.META.get('REMOTE_ADDR', '')
+        if 'HTTP_X_REAL_IP' in request.META:
+            # record real ip from header if was set
+            self.ip = request.META.get('HTTP_X_REAL_IP', '')
+        else:
+            self.ip = request.META.get('REMOTE_ADDR', '')
         self.referer = request.META.get('HTTP_REFERER', '')[:255]
         self.user_agent = request.META.get('HTTP_USER_AGENT', '')[:255]
         self.language = request.META.get('HTTP_ACCEPT_LANGUAGE', '')[:255]

--- a/request/templatetags/request_tag.py
+++ b/request/templatetags/request_tag.py
@@ -2,8 +2,6 @@
 from django import template
 from request.models import Request
 
-import urllib2
-
 register = template.Library()
 
 
@@ -58,16 +56,3 @@ def active_users(parser, token):
         {% endfor %}
     """
     return ActiveUserNode(parser, token)
-
-
-@register.simple_tag
-def page_hits(path):
-    """
-    :param path: page url path, call this way in templates: {% page_hits request.get_full_path %}
-    urllib2.unquote and utf-8 encode needed to support unicode urls
-    :return: number of page hits
-    """
-    path = urllib2.unquote(path.encode('utf-8'))
-    qs = Request.objects.filter(path=path)
-    hits = qs.count()
-    return hits + 1

--- a/request/templatetags/request_tag.py
+++ b/request/templatetags/request_tag.py
@@ -2,6 +2,8 @@
 from django import template
 from request.models import Request
 
+import urllib2
+
 register = template.Library()
 
 
@@ -56,3 +58,16 @@ def active_users(parser, token):
         {% endfor %}
     """
     return ActiveUserNode(parser, token)
+
+
+@register.simple_tag
+def page_hits(path):
+    """
+    :param path: page url path, call this way in templates: {% page_hits request.get_full_path %}
+    urllib2.unquote and utf-8 encode needed to support unicode urls
+    :return: number of page hits
+    """
+    path = urllib2.unquote(path.encode('utf-8'))
+    qs = Request.objects.filter(path=path)
+    hits = qs.count()
+    return hits + 1

--- a/request/templatetags/request_tag.py
+++ b/request/templatetags/request_tag.py
@@ -2,6 +2,8 @@
 from django import template
 from request.models import Request
 
+import urllib2
+
 register = template.Library()
 
 
@@ -56,3 +58,15 @@ def active_users(parser, token):
         {% endfor %}
     """
     return ActiveUserNode(parser, token)
+
+@register.simple_tag
+def page_hits(path):
+    """
+    :param path: page url path, call this way in templates: {% page_hits request.get_full_path %}
+    urllib2.unquote and utf-8 encode needed to support unicode urls
+    :return: number of page hits
+    """
+    path = urllib2.unquote(path.encode('utf-8'))
+    qs = Request.objects.filter(path=path)
+    hits = qs.count()
+    return hits + 1

--- a/request/utils.py
+++ b/request/utils.py
@@ -127,3 +127,22 @@ engines = patterns(
     (r'^https?:\/\/([\.\w]+)?google.*(?:&|\?)q=(?P<keywords>[\+-_\w]+)', 'Google'),
     (r'^https?:\/\/([\.\w]+)?bing.*(?:&|\?)q=(?P<keywords>[\+-_\w]+)', 'Bing'),
 )
+
+
+# transformation of request headers to upper case with underlines
+def transform_http_headers(request):
+    for header in request.META:
+        if header and ':' in header:
+            k, v = header.split(':', 1)
+            v = v.strip()
+
+            if '-' in header:
+                k = k.replace('-', '_').upper()
+
+            if k in request.META:
+                continue  # skip content length, type,etc.
+            if 'HTTP_'+k in request.META:
+                request.META['HTTP_'+k] += ',' + v  # comma-separate multiple headers
+            else:
+                request.META['HTTP_'+k] = v
+


### PR DESCRIPTION
http headers should transformed to a standard case so we can determine and get correct header, like http_x_real_ip from nginx.
