### PR TITLE
Fix NaN time on latest request overview in Firefox (#108)

### DIFF
--- a/request/static/request/js/jquery.relatize_date.js
+++ b/request/static/request/js/jquery.relatize_date.js
@@ -7,7 +7,8 @@
   }
 
   $.relatizeDate = function(element) {
-    return $.relatizeDate.timeAgoInWords( new Date($(element).text()) )
+    var da = $(element).text().split(' ');
+    return $.relatizeDate.timeAgoInWords(new Date(da[1] + ' ' + da[2] + ', ' + da[5] + ' ' + da[3] + ' UTC'));
   }
 
   // shortcut


### PR DESCRIPTION
Reorder the date string in a way that can be parsed by Firefox.