### PR TITLE
make middleware django 1.10 compatible

### DIFF
--- a/request/middleware.py
+++ b/request/middleware.py
@@ -4,7 +4,15 @@ from request.models import Request
 from request.router import patterns
 
 
-class RequestMiddleware(object):
+try:
+    # needed to support Django >= 1.10 MIDDLEWARE
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    # needed to keep Django <= 1.9 MIDDLEWARE_CLASSES
+    MiddlewareMixin = object
+
+
+class RequestMiddleware(MiddlewareMixin):
     def process_response(self, request, response):
         if request.method.lower() not in settings.VALID_METHOD_NAMES:
             return response


### PR DESCRIPTION
This change adds compatibility for Django 1.10 while keeping backwards compatibility.
See [Django documentation](https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware)
