### PR TITLE
custom user model

### DIFF
--- a/request/admin.py
+++ b/request/admin.py
@@ -39,7 +39,7 @@ class RequestAdmin(admin.ModelAdmin):
             user = obj.get_user()
             return format_html(
                 '<a href="?user__username={0}" title="{1}">{2}</a>',
-                user.username,
+                user.get_username(),
                 _('Show only requests from this user.'),
                 user,
             )

--- a/request/admin.py
+++ b/request/admin.py
@@ -31,15 +31,12 @@ class RequestAdmin(admin.ModelAdmin):
     raw_id_fields = ('user',)
     readonly_fields = ('time',)
 
-    def lookup_allowed(self, key, value):
-        return key == 'user__username' or super(RequestAdmin, self).lookup_allowed(key, value)
-
     def request_from(self, obj):
         if obj.user_id:
             user = obj.get_user()
             return format_html(
-                '<a href="?user__username={0}" title="{1}">{2}</a>',
-                user.get_username(),
+                '<a href="?user={0}" title="{1}">{2}</a>',
+                user.pk,
                 _('Show only requests from this user.'),
                 user,
             )

--- a/request/admin.py
+++ b/request/admin.py
@@ -31,14 +31,16 @@ class RequestAdmin(admin.ModelAdmin):
     raw_id_fields = ('user',)
     readonly_fields = ('time',)
 
+    def get_queryset(self, request):
+        return super(RequestAdmin, self).get_queryset(request).select_related('user')
+
     def request_from(self, obj):
         if obj.user_id:
-            user = obj.get_user()
             return format_html(
                 '<a href="?user={0}" title="{1}">{2}</a>',
-                user.pk,
+                obj.user_id,
                 _('Show only requests from this user.'),
-                user,
+                obj.user,
             )
         return format_html(
             '<a href="?ip={0}" title="{1}">{0}</a>',

--- a/request/middleware.py
+++ b/request/middleware.py
@@ -34,7 +34,7 @@ class RequestMiddleware(MiddlewareMixin):
             return response
 
         if getattr(request, 'user', False):
-            if request.user.username in settings.IGNORE_USERNAME:
+            if request.user.get_username() in settings.IGNORE_USERNAME:
                 return response
 
         r = Request()

--- a/request/templates/request/plugins/activeusers.html
+++ b/request/templates/request/plugins/activeusers.html
@@ -9,7 +9,7 @@
     {% active_users in 5 minutes as user_list %}
     {% for user in user_list %}
         <tr>
-            <td><a href="{{ user.get_absolute_url }}">{{ user.username }}</a></td>
+            <td><a href="{{ user.get_absolute_url }}">{{ user.get_username() }}</a></td>
         </tr>
     {% endfor %}
 {% endblock %}

--- a/request/templates/request/plugins/activeusers.html
+++ b/request/templates/request/plugins/activeusers.html
@@ -9,7 +9,7 @@
     {% active_users in 5 minutes as user_list %}
     {% for user in user_list %}
         <tr>
-            <td><a href="{{ user.get_absolute_url }}">{{ user.get_username() }}</a></td>
+            <td><a href="{{ user.get_absolute_url }}">{{ user.get_username }}</a></td>
         </tr>
     {% endfor %}
 {% endblock %}

--- a/request/templatetags/request_tag.py
+++ b/request/templatetags/request_tag.py
@@ -53,7 +53,7 @@ def active_users(parser, token):
         {% load request_tag %}
         {% active_users in 10 minutes as user_list %}
         {% for user in user_list %}
-            {{ user.get_username() }}
+            {{ user.get_username }}
         {% endfor %}
     '''
     return ActiveUserNode(parser, token)

--- a/request/templatetags/request_tag.py
+++ b/request/templatetags/request_tag.py
@@ -53,7 +53,7 @@ def active_users(parser, token):
         {% load request_tag %}
         {% active_users in 10 minutes as user_list %}
         {% for user in user_list %}
-            {{ user.username }}
+            {{ user.get_username() }}
         {% endfor %}
     '''
     return ActiveUserNode(parser, token)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -88,6 +88,11 @@ class RequestAdminViewsTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
+    def test_changelist(self):
+        url = reverse('admin:request_request_changelist')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
     def test_traffic(self):
         url = reverse('admin:request_request_traffic')
         response = self.client.get(url)


### PR DESCRIPTION
In my project I use a custom user model that does not have a username field. See the official documentation for an example: https://docs.djangoproject.com/en/1.11/topics/auth/customizing/#django.contrib.auth.models.CustomUser

django-request chokes with such a model (both in the middleware and in the admin) with an unknown field error.

This pull-request replaces usage of the username field (which may not be present in the user model) by usage of the get_username() method that is always there.

This pull-request solves the same problem as https://github.com/django-request/django-request/pull/132 , but without requiring any extra configuration.

I tried to add extra tests to verify that django-requests works even with a custom user model (see trial here: https://github.com/skioo/django-request/commit/4f5529f7616e28704ed9ee3fbc37fb2a5f58d8da ) but when I swap out the default user model by setting AUTH_USER_MODEL to 'tests.MyUser' then  the test fails because the Request model was loaded at the beginning of the test and the user field expects a django.contrib.auth.models.User. Any help with that test would be appreciated.

