### PR TITLE
put traffic diagram legend to top-left corner

### DIFF
--- a/request/static/request/js/jquery.flot.js
+++ b/request/static/request/js/jquery.flot.js
@@ -45,7 +45,7 @@
                     labelFormatter: null, // fn: string -> string
                     labelBoxBorderColor: "#ccc", // border color for the little label boxes
                     container: null, // container (as jQuery object) to put legend in, null means default on top of graph
-                    position: "ne", // position of default legend container within plot
+                    position: "nw", // position of default legend container within plot
                     margin: 5, // distance from grid edge to default legend container within plot
                     backgroundColor: null, // null means auto-detect
                     backgroundOpacity: 0.85 // set to 0 to avoid background


### PR DESCRIPTION
otherwise obscures the most recent data, which is likely the most
interesting.

Tested locally:

![django-req](https://user-images.githubusercontent.com/1842780/30799409-0e485636-a1dd-11e7-82b9-8aedbdeaec55.png)


Closes #153.