### PR TITLE
Removed unnecessary RequestManagerTest.tearDown().

### DIFF
--- a/tests/test_managers.py
+++ b/tests/test_managers.py
@@ -14,10 +14,6 @@ class RequestManagerTest(TestCase):
         self.user = get_user_model().objects.create(username='foo')
         self.user_2 = get_user_model().objects.create(username='bar')
 
-    def tearDown(self):
-        self.user.delete()
-        self.user_2.delete()
-
     def test_getattr(self):
         for meth in QUERYSET_PROXY_METHODS:
             Request.objects.__getattr__(meth)


### PR DESCRIPTION
Unnecessary since its introduction in 632f4f21bca90477640846e58699dc62a0c756e3.