### PR TITLE
allow non-model request.user to be used

### DIFF
--- a/request/models.py
+++ b/request/models.py
@@ -73,7 +73,7 @@ class Request(models.Model):
             if django.VERSION < (1, 10):
                 is_authenticated = is_authenticated()
             if is_authenticated:
-                self.user = request.user
+                self.user_id = request.user_id
 
         if response:
             self.response = response.status_code


### PR DESCRIPTION
using `user_id` instead of user instance from the request make it possible for
duck typing behaviour