### PR TITLE
Used six package instead of django.utils.six.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Requirements
 * **Python**: 2.7, 3.4, 3.6
 * **Django**: 1.10, 1.11, 2.0, 2.1
 * **python-dateutil**
+* **six**
 
 django-request [1.5.1](https://pypi.org/project/django-request/1.5.1/) is the last version that supports Django 1.4, 1.5, 1.6.
 django-request [1.5.4](https://pypi.org/project/django-request/1.5.4/) is the

--- a/request/models.py
+++ b/request/models.py
@@ -5,8 +5,8 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
+from six import python_2_unicode_compatible
 
 from . import settings as request_settings
 from .managers import RequestManager

--- a/request/router.py
+++ b/request/router.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import re
 
-from django.utils.six import string_types
+from six import string_types
 
 
 class RegexPattern(object):

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     install_requires=[
         'Django>=1.10',
         'python-dateutil',
+        'six',
     ],
     license=request.__licence__,
     classifiers=[

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -4,11 +4,11 @@ from datetime import timedelta
 import mock
 from django.core.management.base import CommandError
 from django.test import TestCase
-from django.utils.six import StringIO
 from django.utils.timezone import now
 from request.management.commands.purgerequests import Command as PurgeRequest
 from request.management.commands.purgerequests import DURATION_OPTIONS
 from request.models import Request
+from six import StringIO
 
 
 class PurgeRequestsTest(TestCase):


### PR DESCRIPTION
`django.utils.six` has been removed in Django 3.0.