### PR TITLE
Fixed #197 -- Fixed ugettext_lazy() deprecation warnings for Django 3.0.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ dist/
 *.sw[pon]
 .coverage
 .tox
+
+# IntelliJ project and module files
+.idea
+*.iml

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,3 @@ dist/
 *.sw[pon]
 .coverage
 .tox
-
-# IntelliJ project and module files
-.idea
-*.iml

--- a/request/admin.py
+++ b/request/admin.py
@@ -8,7 +8,7 @@ from django.contrib import admin
 from django.http import HttpResponse
 from django.shortcuts import render
 from django.utils.html import format_html
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .models import Request
 from .plugins import plugins

--- a/request/models.py
+++ b/request/models.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import models
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from six import python_2_unicode_compatible
 
 from . import settings as request_settings

--- a/request/traffic.py
+++ b/request/traffic.py
@@ -4,8 +4,8 @@ from time import mktime
 import django
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Count
-from django.utils.translation import ugettext
 from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ugettext
 
 from . import settings
 from .utils import get_verbose_name

--- a/request/traffic.py
+++ b/request/traffic.py
@@ -5,7 +5,7 @@ import django
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Count
 from django.utils.translation import ugettext
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from . import settings
 from .utils import get_verbose_name

--- a/request/utils.py
+++ b/request/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import re
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from .router import Patterns
 


### PR DESCRIPTION
#197
- Fixed deprecaation warning by replacing gettext import in utils.py
- Added IntelliJ files to .gitignore