### PR TITLE
Made REQUEST_IGNORE_AJAX ignore htmx requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Enhancements
 
+* Adds [htmx](https://htmx.org/) support to the ``REQUEST_IGNORE_AJAX``
+  setting.
+
 * Confirms support for Django 4.0.
 
 * Confirms support for Django 3.2.

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -9,9 +9,10 @@ Settings
 
 Default: ``False``
 
-If this is set to ``True``, then ajax requests will not be recorded. To
-determine if a request was ajax, we use ``HttpRequest.is_ajax()``, see
-Django documentation for more information.
+If this is set to ``True``, then AJAX requests will not be recorded. To
+determine if a request was AJAX, we check that:
+
+- ``X-Requested-With`` header is set to ``XMLHttpRequest``
 
 ``REQUEST_IGNORE_IP``
 =====================

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -12,7 +12,10 @@ Default: ``False``
 If this is set to ``True``, then AJAX requests will not be recorded. To
 determine if a request was AJAX, we check that:
 
-- ``X-Requested-With`` header is set to ``XMLHttpRequest``
+- ``X-Requested-With`` header is set to ``XMLHttpRequest`` or
+- ``HX-Request`` header is set to ``true`` (`htmx requests`_)
+
+.. _htmx requests: https://htmx.org/
 
 ``REQUEST_IGNORE_IP``
 =====================

--- a/request/utils.py
+++ b/request/utils.py
@@ -158,7 +158,10 @@ def get_verbose_name(class_name):
 
 
 def request_is_ajax(request):
-    return request.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest'
+    return (
+        request.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest' or
+        request.META.get('HTTP_HX_REQUEST') == 'true'  # htmx
+    )
 
 
 def handle_naive_datetime(value):

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -90,6 +90,16 @@ class RequestMiddlewareTest(TestCase):
         self.middleware(request)
         self.assertEqual(1, Request.objects.count())
 
+    @mock.patch('request.middleware.settings.IGNORE_AJAX', True)
+    def test_dont_record_htmx(self):
+        request = self.factory.get('/foo')
+        # Non-htmx
+        self.middleware(request)
+        # htmx
+        request.META['HTTP_HX_REQUEST'] = 'true'
+        self.middleware(request)
+        self.assertEqual(Request.objects.count(), 1)
+
     @mock.patch('request.middleware.settings.IGNORE_AJAX',
                 False)
     def test_record_ajax(self):
@@ -100,6 +110,16 @@ class RequestMiddlewareTest(TestCase):
         request.META['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest'
         self.middleware(request)
         self.assertEqual(2, Request.objects.count())
+
+    @mock.patch('request.middleware.settings.IGNORE_AJAX', False)
+    def test_record_htmx(self):
+        request = self.factory.get('/foo')
+        # Non-htmx
+        self.middleware(request)
+        # htmx
+        request.META['HTTP_HX_REQUEST'] = 'true'
+        self.middleware(request)
+        self.assertEqual(Request.objects.count(), 2)
 
     @mock.patch('request.middleware.settings.IGNORE_IP',
                 ('1.2.3.4',))


### PR DESCRIPTION
As [htmx](https://htmx.org/) becomes increasingly popular with the Django community and can just be as spammy as `Ajax`, having an option to ignore it would be quite handy.

Similarly, the model could be extended by a `BooleanField`to indicate if a request is htmx.

Alternatively, this could also be refactored to behave similarly to ignoring user agents. Specifying a list of headers and ignoring the request whenever one of the headers is set might be more versatile.