### PR TITLE
Refs #233 -- Added warning logging to middleware on invalid IP address in REMOTE_ADDR.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.6.1
 
+### Enhancements
+
+* Adds warning logging to middleware on invalid IP addresses in
+  ``REMOTE_ADDR``.
+
 ### Bug Fixes
 
 * Adds a missing migration to change ``help_text`` of ``Request.is_ajax``.

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -136,7 +136,12 @@ class RequestMiddlewareTest(TestCase):
     def test_invalid_addr(self):
         request = self.factory.get('/foo')
         request.META['REMOTE_ADDR'] = 'invalid-addr'
-        self.middleware(request)
+        with self.assertLogs('request.security.middleware', 'WARNING') as cm:
+            self.middleware(request)
+        self.assertIn(
+            "Bad request: {'ip': ['Enter a valid IPv4 or IPv6 address.']}",
+            cm.output[0],
+        )
         self.assertEqual(Request.objects.count(), 0)
 
     @mock.patch('request.middleware.settings.IGNORE_USER_AGENTS',


### PR DESCRIPTION
Follow up to 55d596d4a641c6318d06f1b2de3600e58f43e3c9.

See https://github.com/django-request/django-request/pull/234#issuecomment-998263414.

@blag What do you think? Does it work for you?