### PR TITLE
Made REQUEST_IGNORE_AJAX don't ignore boosted htmx requests. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog for django-request
 
+## 1.6.2
+
+### Enhancements
+
+* Don't ignore [boosted htmx requests](https://htmx.org/attributes/hx-boost/)
+  with ``REQUEST_IGNORE_AJAX``.
+
 ## 1.6.1
 
 ### Enhancements

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -13,9 +13,11 @@ If this is set to ``True``, then AJAX requests will not be recorded. To
 determine if a request was AJAX, we check that:
 
 - ``X-Requested-With`` header is set to ``XMLHttpRequest`` or
-- ``HX-Request`` header is set to ``true`` (`htmx requests`_)
+- ``HX-Request`` header is set to ``true`` (`htmx requests`_) and
+  ``HX-Boosted`` is not set to ``true`` (`boosted requests`_ are not ignored)
 
 .. _htmx requests: https://htmx.org/
+.. _boosted requests: https://htmx.org/attributes/hx-boost/
 
 ``REQUEST_IGNORE_IP``
 =====================

--- a/request/utils.py
+++ b/request/utils.py
@@ -160,7 +160,12 @@ def get_verbose_name(class_name):
 def request_is_ajax(request):
     return (
         request.META.get('HTTP_X_REQUESTED_WITH') == 'XMLHttpRequest' or
-        request.META.get('HTTP_HX_REQUEST') == 'true'  # htmx
+        # Htmx.
+        (
+            request.META.get('HTTP_HX_REQUEST') == 'true' and
+            # Do not ignore boosted htmx requests.
+            request.META.get('HTTP_HX_BOOSTED') != 'true'
+        )
     )
 
 

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -100,6 +100,15 @@ class RequestMiddlewareTest(TestCase):
         self.middleware(request)
         self.assertEqual(Request.objects.count(), 1)
 
+    @mock.patch('request.middleware.settings.IGNORE_AJAX', True)
+    def test_record_boosted_html(self):
+        self.assertEqual(Request.objects.count(), 0)
+        request = self.factory.get('/foo')
+        request.META['HTTP_HX_REQUEST'] = 'true'
+        request.META['HTTP_HX_BOOSTED'] = 'true'
+        self.middleware(request)
+        self.assertEqual(Request.objects.count(), 1)
+
     @mock.patch('request.middleware.settings.IGNORE_AJAX',
                 False)
     def test_record_ajax(self):


### PR DESCRIPTION
HTMX allows for *boosting* links, which enhances normal `<a>` tags to give it a SPA-feeling. Therefore it is likely undesirable to not log boosted htmx requests.

edit: Sorry for three commits that really should only be one...