### PR TITLE
Added edge/chrome distinction & fixed year view of traffic graph 

### DIFF
--- a/request/admin.py
+++ b/request/admin.py
@@ -86,12 +86,15 @@ class RequestAdmin(admin.ModelAdmin):
         if days_count < 10:
             days_step = 1
         elif days_count < 60:
-            days_step = 2
+            days_step = 1
         else:
             days_step = 30
 
         days = [date.today() - timedelta(day) for day in range(0, days_count + 1, days_step)]
-        days_qs = [(day, Request.objects.day(date=day)) for day in days]
+        if days_step == 30:
+            days_qs = [(day, Request.objects.filter(time__month=day.month, time__year=day.year)) for day in days]
+        else:
+            days_qs = [(day, Request.objects.day(date=day)) for day in days]
         return HttpResponse(json.dumps(modules.graph(days_qs)), content_type='text/javascript')
 
 

--- a/request/admin.py
+++ b/request/admin.py
@@ -29,6 +29,8 @@ class RequestAdmin(admin.ModelAdmin):
     )
     raw_id_fields = ('user',)
     readonly_fields = ('time',)
+    search_fields = ['user__username', 'path', 'time']
+    list_filter = ('method', 'time', 'user')
 
     def get_queryset(self, request):
         return super().get_queryset(request).select_related('user')

--- a/request/static/request/js/request.js
+++ b/request/static/request/js/request.js
@@ -23,8 +23,11 @@ function showTooltip(x, y, contents) {
 var previousPoint = null;
 var date = new Date();
 
-function trafficGraph(placeholder, data) {
+var DAYS_PERIOD = null;
+
+function trafficGraph(placeholder, data, days=null) {
     var plot = $.plot(placeholder, data, {xaxis:{mode:'time'}, points:{show:true}, lines:{show:true}, grid:{hoverable:true}});
+    DAYS_PERIOD = days
     
     placeholder.bind("plothover", function (event, pos, item) {
         if (item) {
@@ -32,7 +35,10 @@ function trafficGraph(placeholder, data) {
                 previousPoint = item.datapoint;
                 
                 date.setTime(item.datapoint[0]).toString;
-                showTooltip(item.pageX, item.pageY, item.series.label + ' on ' + monthNames[date.getMonth()] + ' ' + date.getDate() + ' is ' + item.datapoint[1]);
+                if(DAYS_PERIOD==365)
+                    showTooltip(item.pageX, item.pageY, item.series.label + ' on ' + monthNames[date.getMonth()] + ' is ' + item.datapoint[1]);
+                else
+                    showTooltip(item.pageX, item.pageY, item.series.label + ' on ' + monthNames[date.getMonth()] + ' ' + date.getDate() + ' is ' + item.datapoint[1]);
             }
         } else {
             $("#tooltip").remove();

--- a/request/templates/admin/request/request/overview.html
+++ b/request/templates/admin/request/request/overview.html
@@ -16,7 +16,7 @@
             }
 
             $.getJSON(path, function(data) {
-                trafficGraph($("#trafficgraph"), data);
+                trafficGraph($("#trafficgraph"), data, days);
             });
         }
 

--- a/request/utils.py
+++ b/request/utils.py
@@ -83,7 +83,8 @@ browsers = Patterns(
         'AOL',
     ),
     (r'Camino/(?P<version>[-.\w]+)', 'Camino'),
-    (r'Chrome/(?P<version>[-.\w]+)', 'Google Chrome'),
+    (r'Chrome/(?P<version>[-.\w]+)(?!.*Edg).*', 'Google Chrome'),
+    (r'Edg(A|iOS)?/(?P<version>[-.\w]+)', 'Microsoft Edge'),
     (r'Firefox(/(?P<version>[-.\w]+)?)', 'Firefox'),
     (
         r'Mozilla/(?P<mozilla_version>[-.\w]+) \(compatible; ( ?)MSIE (?P<version>[-.\w]+); ' +


### PR DESCRIPTION
I have optimized following things and tested on django 3.2:

- Added search & filters in admin panel for requests search
- Added a separate entry for Edge (was considered chrome by django-request)
- Traffic graph for year now has sum of months (instead of traffic of same date on previous months)
- Traffic graph for month now plots all days instead of alternate days