### PR TITLE
client or remote_addr IP

### DIFF
--- a/request/models.py
+++ b/request/models.py
@@ -8,7 +8,7 @@ from django.utils.translation import gettext_lazy as _
 
 from . import settings as request_settings
 from .managers import RequestManager
-from .utils import HTTP_STATUS_CODES, browsers, engines, request_is_ajax
+from .utils import HTTP_STATUS_CODES, browsers, engines, request_is_ajax,get_client_or_remote_ip
 
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 
@@ -59,7 +59,8 @@ class Request(models.Model):
         self.is_ajax = request_is_ajax(request)
 
         # User information.
-        self.ip = request.META.get('REMOTE_ADDR', '')
+        # self.ip = request.META.get('REMOTE_ADDR', '')
+        self.ip = get_client_or_remote_ip(request)
         self.referer = request.META.get('HTTP_REFERER', '')[:255]
         self.user_agent = request.META.get('HTTP_USER_AGENT', '')[:255]
         self.language = request.META.get('HTTP_ACCEPT_LANGUAGE', '')[:255]
@@ -115,3 +116,4 @@ class Request(models.Model):
             self.user = None
 
         super().save(*args, **kwargs)
+

--- a/request/utils.py
+++ b/request/utils.py
@@ -173,3 +173,13 @@ def handle_naive_datetime(value):
     if settings.USE_TZ and timezone.is_naive(value):
         return timezone.make_aware(value)
     return value
+
+def get_client_or_remote_ip(request):
+    x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
+    if x_forwarded_for:
+        ip = x_forwarded_for.split(',')[-1].strip()
+    elif request.META.get('HTTP_X_REAL_IP'):
+        ip = request.META.get('HTTP_X_REAL_IP')
+    else:
+        ip = request.META.get('REMOTE_ADDR')
+    return ip


### PR DESCRIPTION
Couldn't find any way to get http_x_forwarded IP or http_x_real_ip. So, I added a simple function if any case someone like me is using Nginx or another server and want the client_ip. If, not they will get REMOTE_ADDR by default.