### PR TITLE
Issue #172  Added response_time to Request model and the necessary adjustments to RequestMiddleware

### DIFF
--- a/request/migrations/0009_add_response_time.py
+++ b/request/migrations/0009_add_response_time.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('request', '0008_alter_request_response_choices'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='request',
+            name='response_time',
+            field=models.FloatField(null=True, verbose_name='response_time'),
+        ),
+    ]

--- a/request/models.py
+++ b/request/models.py
@@ -21,6 +21,7 @@ class Request(models.Model):
     method = models.CharField(_('method'), default='GET', max_length=7)
     path = models.CharField(_('path'), max_length=255)
     time = models.DateTimeField(_('time'), default=timezone.now, db_index=True)
+    response_time = models.FloatField(_('response_time'), null=True)
 
     is_secure = models.BooleanField(_('is secure'), default=False)
     is_ajax = models.BooleanField(
@@ -50,8 +51,9 @@ class Request(models.Model):
     def get_user(self):
         return get_user_model().objects.get(pk=self.user_id)
 
-    def from_http_request(self, request, response=None, commit=True):
+    def from_http_request(self, request, response=None, response_time=None, commit=True):
         # Request information.
+        self.response_time = response_time
         self.method = request.method
         self.path = request.path[:255]
 


### PR DESCRIPTION
- Added response_time (FloatField) to Request model.  Modified the from_http_request method to accept the response_time

- Created migration for new response_time field

- Modified RequestMiddlware to not use depreciated MiddlewareMixin.  Middleware now captures response_time and passes it to Request.from_http_method.   

- Created a hook in the middleware for creating the Request instance so that people that want to extend the middleware (like I did) can capture the created instance and perhaps OneToOneFK to it. 
