### PR TITLE
Fix Week/Month/Year links colors in Django 5.0.

### DIFF
--- a/request/templates/admin/request/request/overview.html
+++ b/request/templates/admin/request/request/overview.html
@@ -42,7 +42,12 @@
 <div style="width:920px;">
     <div class="module" style="clear: both;">
         <table style="width: 100%;">
-            <caption>{% trans "Traffic graph" %} ( <a href="javascript:loadTrafficGraph(7);">{% trans "Week" %}</a> | <a href="javascript:loadTrafficGraph(30);">{% trans "Month" %}</a> | <a href="javascript:loadTrafficGraph(365);">{% trans "Year" %}</a> )</caption>
+            <caption>
+                {% trans "Traffic graph" %} (
+                <a class="section" href="javascript:loadTrafficGraph(7);">{% trans "Week" %}</a> |
+                <a class="section" href="javascript:loadTrafficGraph(30);">{% trans "Month" %}</a> |
+                <a class="section" href="javascript:loadTrafficGraph(365);">{% trans "Year" %}</a> )
+            </caption>
         </table>
         
         <div style="padding: 15px;">


### PR DESCRIPTION
Follow up to 8d18d4d3b2e120ba9f36af3b1925e890eb118efd.


With this patch:

![image](https://github.com/django-request/django-request/assets/2865885/102f7a66-e287-499e-ba56-006ad31d7463)

Without this patch:

![image](https://github.com/django-request/django-request/assets/2865885/402e4745-295a-44a8-9497-836221839128)